### PR TITLE
PUC-931: Use Camera Api instead of Camera2 when detecting available resolutions

### DIFF
--- a/java/src/org/linphone/mediastream/video/capture/hwconf/AndroidCameraConfiguration.java
+++ b/java/src/org/linphone/mediastream/video/capture/hwconf/AndroidCameraConfiguration.java
@@ -32,7 +32,7 @@ import org.linphone.mediastream.Version;
  */
 public class AndroidCameraConfiguration {
 	public static AndroidCamera[] retrieveCameras() {
-		return retrieveCameras(true);
+		return retrieveCameras(false);
 	}
 
 	public static AndroidCamera[] retrieveCameras(boolean cameraTwoEnabled) {


### PR DESCRIPTION
For detecting available camera resolutions It uses camera api 2 for sdk >=21.
when it shows preview and sends video it always uses camera api (not api 2). So there may be resolutions which are supported using only api 2. That is the case I experience on samsung galaxy tablet. So while we use camera api for sending video we should retrieve available cameras with the same api.
